### PR TITLE
Protect \setcounter in redefinition of \appendix

### DIFF
--- a/thesis-umich.cls
+++ b/thesis-umich.cls
@@ -879,7 +879,7 @@
  % Add the page to the table of contents.
  \addcontentsline{toc}{chapter}{Appendices}
  % Stop adding sections to the table of contents.
- \addtocontents{toc}{\setcounter{tocdepth}{1}} %
+ \addtocontents{toc}{\protect\setcounter{tocdepth}{1}} %
  % Header for appendices.
  \renewcommand{\@chapapp}{APPENDIX} %
  % Renew the chapter and section labels.


### PR DESCRIPTION
Previous version causes error with packages such as calc (loaded by mathtools) that turn \setcounter into a fragile command; see https://tex.stackexchange.com/questions/370518/addtocontents-not-working-with-certain-other-packages and the descendant link https://texfaq.org/FAQ-protect for more information